### PR TITLE
feat: enable specifying a base url

### DIFF
--- a/plexe/client.py
+++ b/plexe/client.py
@@ -5,14 +5,18 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 class PlexeAI:
-    def __init__(self, api_key: Optional[str] = None, timeout: float = 120.0):
+    def __init__(self, api_key: Optional[str] = None, base_url: str = "https://api.plexe.ai/v0", timeout: float = 120.0):
         self.api_key = api_key
         if not api_key:
             self.api_key = os.environ.get("PLEXE_API_KEY")
             if not self.api_key:
                 raise ValueError("PLEXE_API_KEY must be provided or set as environment variable")
+        if not base_url or not isinstance(base_url, str):
+            raise ValueError("base_url must be a non-empty string")
+        if not base_url.startswith("https://"):
+            raise ValueError("base_url must start with 'https://' as Plexe API requires HTTPS")
 
-        self.base_url = "https://api.plexe.ai/v0"
+        self.base_url = base_url
         self.client = httpx.Client(timeout=timeout)
         self.async_client = httpx.AsyncClient(timeout=timeout)
 

--- a/plexe/tests/test_integration.py
+++ b/plexe/tests/test_integration.py
@@ -68,6 +68,12 @@ class TestPlexeAIIntegration:
         assert client.api_key == API_KEY
         assert client.base_url == "https://api.plexe.ai/v0"
 
+    def test_client_initialization_with_baseurl(self):
+        """Test client initialization with custom base URL."""
+        client = PlexeAI(api_key=API_KEY, base_url="https://example.com")
+        assert client.api_key == API_KEY
+        assert client.base_url == "https://example.com"
+
     def test_build_and_inference_flow(self, client, sample_data_file, sample_input_data):
         """Test full flow: build model with direct data files to avoid timing issues."""
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "plexe"
-version = "0.1.3"
+version = "0.2.0"
 description = "Create ML models from natural language descriptions"
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
This PR adds the ability to specify a non-default base URL when instantiation a `PlexeAI` client. This enables using the library on test endpoints etc.